### PR TITLE
Automatically find repository root if not repository folder is provided

### DIFF
--- a/git-heatgrid
+++ b/git-heatgrid
@@ -213,6 +213,9 @@ function parse_args() {
     done
 
     config_repo_path="${positional_args[0]:-.}"
+    if [[ $config_repo_path == . ]]; then
+        config_repo_path="$(git rev-parse --show-toplevel 2> /dev/null || echo .)"
+    fi
 }
 
 function validate_config() {


### PR DESCRIPTION
If one was in a subdirectory of the repository and called `git-heatgrid` it would fail with "Error: The specified directory was not found or is not a git repository" as it would look for the .git directory inside the current working directory. Using `git rev-parse --show-toplevel` we can obtain the root folder of the git repository we are currently in. In case that fails (i.e., we are not inside a git repository) we fall back to "." again.